### PR TITLE
Supports for Madras Env

### DIFF
--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -51,7 +51,7 @@ def learn(network, env,
 
     rank = MPI.COMM_WORLD.Get_rank()
     nb_actions = env.action_space.shape[-1]
-    assert (np.abs(env.action_space.low) == env.action_space.high).all()  # we assume symmetric actions.
+    #assert (np.abs(env.action_space.low) == env.action_space.high).all()  # we assume symmetric actions.
 
     memory = Memory(limit=int(1e6), action_shape=env.action_space.shape, observation_shape=env.observation_space.shape)
     critic = Critic(network=network, **network_kwargs)

--- a/baselines/run.py
+++ b/baselines/run.py
@@ -49,7 +49,7 @@ _game_envs['retro'] = {
     'SpaceInvaders-Snes',
 }
 
-
+_game_envs['madras'] = {'gym-torcs-v0','gym-madras-v0'}
 def train(args, extra_args):
     env_type, env_id = get_env_type(args.env)
     print('env_type: {}'.format(env_type))


### PR DESCRIPTION
This PR adds support for madras Env in baselines.

Testing:
1. clone the baselines and gym.
2. install editable copies of both using `pip install -e` .
3. run `python -m baselines.run --alg=ddpg --env='gym-madras-v0'` from baselines folder.