### PR TITLE
Added Saving functionality.

### DIFF
--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -63,7 +63,6 @@ def learn(network, env,
 
     nb_actions = env.action_space.shape[-1]
     #assert (np.abs(env.action_space.low) == env.action_space.high).all()  # we assume symmetric actions.
-    sess = U.get_session()
     memory = Memory(limit=int(1e6), action_shape=env.action_space.shape, observation_shape=env.observation_space.shape)
     critic = Critic(network=network, **network_kwargs)
     actor = Actor(nb_actions, network=network, **network_kwargs)
@@ -102,9 +101,12 @@ def learn(network, env,
     eval_episode_rewards_history = deque(maxlen=100)
     episode_rewards_history = deque(maxlen=100)
     # Prepare everything.
+    sess = U.get_session()
     agent.initialize(sess)
+    checkpoint_num = 0
     if load_path is not None:
         agent.load(load_path)
+        checkpoint_num = int(os.path.split(load_path)[1]) + 1
     sess.graph.finalize()
 
     agent.reset()
@@ -277,7 +279,7 @@ def learn(network, env,
                 with open(os.path.join(logdir, 'eval_env_state.pkl'), 'wb') as f:
                     pickle.dump(eval_env.get_state(), f)
 
-            savepath = os.path.join(save_path, str(epoch))
+            savepath = os.path.join(save_path, str(epoch+checkpoint_num))
             print('Saving to ', savepath)
             agent.save(savepath)
 

--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -43,7 +43,7 @@ def learn(network, env,
           eval_env=None,
           param_noise_adaption_interval=50,
           load_path = None,
-          save_path = '/home/sohan/check1',
+          save_path = '<specify/path>',
           **network_kwargs):
 
     print("Save PATH;{}".format(save_path))

--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -43,7 +43,7 @@ def learn(network, env,
           eval_env=None,
           param_noise_adaption_interval=50,
           load_path = None,
-          save_path = '<specify/path>'
+          save_path = '<specify/path>',
           **network_kwargs):
 
     set_global_seeds(seed)
@@ -274,7 +274,7 @@ def learn(network, env,
                 with open(os.path.join(logdir, 'eval_env_state.pkl'), 'wb') as f:
                     pickle.dump(eval_env.get_state(), f)
 
-            os.mkdirs(logdir,exist_ok=True)
+            os.makdirs(logdir,exist_ok=True)
             savepath = os.path.join(save_path, str(epoch))
             print('Saving to ',savepath)
             agent.save(savepath)

--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -42,6 +42,8 @@ def learn(network, env,
           tau=0.01,
           eval_env=None,
           param_noise_adaption_interval=50,
+          load_path = None,
+          save_path = '<specify/path>'
           **network_kwargs):
 
     set_global_seeds(seed)
@@ -91,6 +93,9 @@ def learn(network, env,
         batch_size=batch_size, action_noise=action_noise, param_noise=param_noise, critic_l2_reg=critic_l2_reg,
         actor_lr=actor_lr, critic_lr=critic_lr, enable_popart=popart, clip_norm=clip_norm,
         reward_scale=reward_scale)
+
+    if load_path is not None:
+        agent.load(load_path)
     logger.info('Using agent with the following configuration:')
     logger.info(str(agent.__dict__.items()))
 
@@ -268,6 +273,11 @@ def learn(network, env,
             if eval_env and hasattr(eval_env, 'get_state'):
                 with open(os.path.join(logdir, 'eval_env_state.pkl'), 'wb') as f:
                     pickle.dump(eval_env.get_state(), f)
+
+            os.mkdirs(logdir,exist_ok=True)
+            savepath = os.path.join(save_path, str(epoch))
+            print('Saving to ',savepath)
+            agent.save(savepath)
 
 
     return agent

--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -51,7 +51,7 @@ def learn(network, env,
 
     rank = MPI.COMM_WORLD.Get_rank()
     nb_actions = env.action_space.shape[-1]
-    assert (np.abs(env.action_space.low) == env.action_space.high).all()  # we assume symmetric actions.
+    #assert (np.abs(env.action_space.low) == env.action_space.high).all()  # we assume symmetric actions.
 
     memory = Memory(limit=int(1e6), action_shape=env.action_space.shape, observation_shape=env.observation_space.shape)
     critic = Critic(network=network, **network_kwargs)

--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -274,9 +274,9 @@ def learn(network, env,
                 with open(os.path.join(logdir, 'eval_env_state.pkl'), 'wb') as f:
                     pickle.dump(eval_env.get_state(), f)
 
-            os.makdirs(logdir,exist_ok=True)
+            os.makedirs(logdir, exist_ok=True)
             savepath = os.path.join(save_path, str(epoch))
-            print('Saving to ',savepath)
+            print('Saving to ', savepath)
             agent.save(savepath)
 
 

--- a/baselines/ddpg/ddpg_learner.py
+++ b/baselines/ddpg/ddpg_learner.py
@@ -1,6 +1,7 @@
 from copy import copy
 from functools import reduce
 
+import functools
 import numpy as np
 import tensorflow as tf
 import tensorflow.contrib as tc
@@ -9,6 +10,7 @@ from baselines import logger
 from baselines.common.mpi_adam import MpiAdam
 import baselines.common.tf_util as U
 from baselines.common.mpi_running_mean_std import RunningMeanStd
+from baselines.common.tf_util import save_variables, load_variables
 try:
     from mpi4py import MPI
 except ImportError:
@@ -98,6 +100,8 @@ class DDPG(object):
         self.batch_size = batch_size
         self.stats_sample = None
         self.critic_l2_reg = critic_l2_reg
+        self.save = None
+        self.load = None
 
         # Observation normalization.
         if self.normalize_observations:
@@ -333,6 +337,8 @@ class DDPG(object):
     def initialize(self, sess):
         self.sess = sess
         self.sess.run(tf.global_variables_initializer())
+        self.save = functools.partial(save_variables, sess=self.sess)
+        self.load = functools.partial(load_variables, sess=self.load)
         self.actor_optimizer.sync()
         self.critic_optimizer.sync()
         self.sess.run(self.target_init_updates)

--- a/baselines/run.py
+++ b/baselines/run.py
@@ -49,7 +49,7 @@ _game_envs['retro'] = {
     'SpaceInvaders-Snes',
 }
 
-
+_game_envs['madras'] = {'gym-torcs-v0','gym-madras-v0'}
 def train(args, extra_args):
     env_type, env_id = get_env_type(args.env)
     print('env_type: {}'.format(env_type))

--- a/baselines/run.py
+++ b/baselines/run.py
@@ -5,7 +5,7 @@ import gym
 from collections import defaultdict
 import tensorflow as tf
 import numpy as np
-
+import MADRaS
 from baselines.common.vec_env.vec_video_recorder import VecVideoRecorder
 from baselines.common.vec_env.vec_frame_stack import VecFrameStack
 from baselines.common.cmd_util import common_arg_parser, parse_unknown_args, make_vec_env, make_env


### PR DESCRIPTION
Why?
There was no previous option to support the saving of trained networks(ddpg). Hence to add that functionality.

What?
Built a saving function where you can manually specify a dir for the network to save and can also load the desired model back.

Testing

_For saving:_
Specify the path of the save directory in the field `specify/path` in the `ddpg.py`. Then run the code as usual. `python -m baselines.run --alg='ddpg' --env='Madras-v0'`

_For loading:_
`python -m baselines.run --alg='ddpg' --env='Madras-v0' --load_path=/specify/path/to/save/file`

NOTE: 
The save function takes in a dir whereas the load function takes in a file.
This PR also includes #1 as that will be required for madras-env to be working.
